### PR TITLE
fix: enhance constuctor

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -9,13 +9,11 @@ export class PrismaAdapter implements Adapter {
   #option?: Prisma.PrismaClientOptions;
   #prisma: PrismaClient;
 
-  constructor(
-    option?: Prisma.PrismaClientOptions,
-    prismaClient?: PrismaClient
-  ) {
-    this.#option = option;
-    if (prismaClient) {
-      this.#prisma = prismaClient;
+  constructor(option?: Prisma.PrismaClientOptions | PrismaClient) {
+    if (option instanceof PrismaClient) {
+      this.#prisma = option;
+    } else {
+      this.#option = option;
     }
   }
 


### PR DESCRIPTION
ref to discussion at https://github.com/node-casbin/prisma-adapter/pull/25#discussion_r616556606

In TypeScript, constuctor didn't support overload. I didn't find an elegant way to implement this.

Any suggestion? @Sefriol @hsluoyz 