### PR TITLE
Use DSL to remove records vs. SQL

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -30,7 +30,7 @@ export class PrismaAdapter implements Adapter {
   }
 
   async savePolicy(model: Model): Promise<boolean> {
-    await this.#prisma.$executeRaw`DELETE FROM casbin_rule;`;
+    await this.#prisma.casbinRule.deleteMany();
 
     let astMap = model.model.get('p')!;
     const processes: Array<Promise<CasbinRule>> = [];


### PR DESCRIPTION
The SQL generated is subtly different -- I don't know enough about Prisma or Casbin to know if this is an issue, but I suspect it's ok?

```sql
DELETE FROM `nextnext`.`CasbinRule` WHERE (`nextnext`.`CasbinRule`.`id` IN (?) AND 1=1)
```

Primary benefit is removing dependency on the underlying table name (hence the `@@map` directive in the schema can be removed).