### PR TITLE
feat: add PrismaAdapter.newAdapter(prisma) constructor and fix prismaclient instanceof failure

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -24,10 +24,11 @@ export class PrismaAdapter implements Adapter {
    * You should later call open() to activate it.
    */
   constructor(option?: Prisma.PrismaClientOptions | PrismaClient) {
-    if (option instanceof PrismaClient) {
-      this.#prisma = option;
-    } else {
-      this.#option = option;
+    if (option && typeof (option as PrismaClient).$connect === 'function') {
+      // If option is PrismaClient, we use it directly.
+      this.#prisma = option as PrismaClient;
+    } else if (option) {
+      this.#option = option as Prisma.PrismaClientOptions;
     }
   }
 

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { PrismaClient } from '@prisma/client';
 import { newEnforcer, Enforcer, Util } from 'casbin';
 import { PrismaAdapter } from '../src/adapter';
 
@@ -35,7 +36,8 @@ async function testGetGroupingPolicy(
 test(
   'TestAdapter',
   async () => {
-    const a = await PrismaAdapter.newAdapter();
+    const prisma = new PrismaClient();
+    const a = await PrismaAdapter.newAdapter(prisma);
 
     try {
       // Because the DB is empty at first,


### PR DESCRIPTION
This pull request refactors the `PrismaAdapter` class to improve type checking and functionality when handling `PrismaClient` instances. It also updates the corresponding tests to reflect these changes.

fixes #62

### Refactoring of `PrismaAdapter`:

* Updated the constructor in `src/adapter.ts` to check if the provided `option` has a `$connect` method, ensuring proper type handling for `PrismaClient` instances. This allows direct usage of `PrismaClient` or its options.

### Updates to tests:

* Added an import for `PrismaClient` in `test/adapter.test.ts` to support the updated constructor logic.
* Modified the `TestAdapter` test to pass a `PrismaClient` instance to `PrismaAdapter.newAdapter`, aligning with the new constructor implementation.